### PR TITLE
Fix a bug where not uploading a new file would lead to an error.

### DIFF
--- a/flask_admin_s3_upload.py
+++ b/flask_admin_s3_upload.py
@@ -64,7 +64,7 @@ class S3FileUploadField(FileUploadField):
 
                 return
 
-        if self.data and self.data.filename and isinstance(self.data, FileStorage):
+        if self.data and isinstance(self.data, FileStorage) and self.data.filename:
             if field:
                 self._delete_file(field, obj)
 

--- a/flask_admin_s3_upload.py
+++ b/flask_admin_s3_upload.py
@@ -17,9 +17,9 @@ from boto.exception import S3ResponseError
 from boto.s3.key import Key
 from werkzeug.datastructures import FileStorage
 
-from flask.ext.admin.form.upload import FileUploadField, ImageUploadInput, thumbgen_filename
+from flask.ext.admin.form.upload import FileUploadField, ImageUploadInput, \
+    thumbgen_filename
 from flask.ext.admin._compat import urljoin
-from flask.ext.admin.helpers import get_url
 
 from url_for_s3 import url_for_s3
 
@@ -38,7 +38,10 @@ class S3FileUploadField(FileUploadField):
         super(S3FileUploadField, self).__init__(label, validators, **kwargs)
 
         if storage_type and (storage_type != 's3'):
-            raise ValueError('Storage type "%s" is invalid, the only supported storage type (apart from default local storage) is s3.' % storage_type)
+            raise ValueError(
+                'Storage type "%s" is invalid, the only supported storage type'
+                ' (apart from default local storage) is s3.' % storage_type
+            )
 
         self.storage_type = storage_type
         self.bucket_name = bucket_name
@@ -64,7 +67,8 @@ class S3FileUploadField(FileUploadField):
 
                 return
 
-        if self.data and self.data.filename and isinstance(self.data, FileStorage):
+        if (self.data and self.data.filename and
+                isinstance(self.data, FileStorage)):
             if field:
                 self._delete_file(field, obj)
 
@@ -90,9 +94,11 @@ class S3FileUploadField(FileUploadField):
 
     def _get_s3_path(self, filename):
         if not self.static_root_parent:
-            raise ValueError('S3FileUploadField field requires static_root_parent to be set.')
+            raise ValueError('S3FileUploadField field requires '
+                             'static_root_parent to be set.')
 
-        return re.sub('^\/', '', self._get_path(filename).replace(self.static_root_parent, ''))
+        return re.sub('^\/', '', self._get_path(filename).replace(
+            self.static_root_parent, ''))
 
     def _delete_file(self, filename, obj):
         storage_type = getattr(obj, self.storage_type_field, '')
@@ -102,7 +108,9 @@ class S3FileUploadField(FileUploadField):
             return super(S3FileUploadField, self)._delete_file(filename)
 
         if storage_type != 's3':
-            raise ValueError('Storage type "%s" is invalid, the only supported storage type (apart from default local storage) is s3.' % storage_type)
+            raise ValueError(
+                'Storage type "%s" is invalid, the only supported storage type'
+                ' (apart from default local storage) is s3.' % storage_type)
 
         conn = S3Connection(self.access_key_id, self.access_key_secret)
         bucket = conn.get_bucket(bucket_name)
@@ -140,7 +148,10 @@ class S3FileUploadField(FileUploadField):
             return self._save_file_local(temp_file, filename)
 
         if self.storage_type != 's3':
-            raise ValueError('Storage type "%s" is invalid, the only supported storage type (apart from default local storage) is s3.' % self.storage_type)
+            raise ValueError(
+                'Storage type "%s" is invalid, the only supported storage type'
+                ' (apart from default local storage) is s3.'
+                % self.storage_type)
 
         conn = S3Connection(self.access_key_id, self.access_key_secret)
         bucket = conn.get_bucket(self.bucket_name)
@@ -171,7 +182,8 @@ class S3ImageUploadInput(ImageUploadInput):
         if field.url_relative_path:
             filename = urljoin(field.url_relative_path, filename)
 
-        return url_for_s3('static', bucket_name=field.bucket_name, filename=filename)
+        return url_for_s3('static', bucket_name=field.bucket_name,
+                          filename=filename)
 
 
 class S3ImageUploadField(S3FileUploadField):
@@ -202,11 +214,13 @@ class S3ImageUploadField(S3FileUploadField):
         self.image = None
         self.url_relative_path = url_relative_path
 
-        if (not ('allowed_extensions' in kwargs)) or not kwargs['allowed_extensions']:
-            kwargs['allowed_extensions'] = ('gif', 'jpg', 'jpeg', 'png', 'tiff')
+        if (not ('allowed_extensions' in kwargs)
+                or not kwargs['allowed_extensions']):
+            kwargs['allowed_extensions'] = \
+                ('gif', 'jpg', 'jpeg', 'png', 'tiff')
 
         super(S3ImageUploadField, self).__init__(label, validators,
-                                               **kwargs)
+                                                 **kwargs)
 
     def pre_validate(self, form):
         super(S3ImageUploadField, self).pre_validate(form)
@@ -240,7 +254,9 @@ class S3ImageUploadField(S3FileUploadField):
             return
 
         if storage_type != 's3':
-            raise ValueError('Storage type "%s" is invalid, the only supported storage type (apart from default local storage) is s3.' % storage_type)
+            raise ValueError(
+                'Storage type "%s" is invalid, the only supported storage type'
+                ' (apart from default local storage) is s3.' % storage_type)
 
         conn = S3Connection(self.access_key_id, self.access_key_secret)
         bucket = conn.get_bucket(bucket_name)
@@ -257,12 +273,14 @@ class S3ImageUploadField(S3FileUploadField):
     # Saving
     def _save_file(self, temp_file, filename):
         if self.storage_type and (self.storage_type != 's3'):
-            raise ValueError('Storage type "%s" is invalid, the only supported storage type (apart from default local storage) is s3.' % storage_type)
+            raise ValueError(
+                'Storage type "%s" is invalid, the only supported storage type'
+                ' (apart from default local storage) is s3.' % storage_type)
 
         # Figure out format
         filename, format = self._get_save_format(filename, self.image)
 
-        if self.image: #and (self.image.format != format or self.max_size):
+        if self.image:    # and (self.image.format != format or self.max_size):
             if self.max_size:
                 image = self._resize(self.image, self.max_size)
             else:
@@ -283,14 +301,16 @@ class S3ImageUploadField(S3FileUploadField):
                              temp_file,
                              format)
 
-            super(S3ImageUploadField, self)._save_file(temp_file, self.thumbnail_fn(filename))
+            super(S3ImageUploadField, self)._save_file(
+                temp_file, self.thumbnail_fn(filename))
 
     def _resize(self, image, size):
         (width, height, force) = size
 
         if image.size[0] > width or image.size[1] > height:
             if force:
-                return ImageOps.fit(self.image, (width, height), Image.ANTIALIAS)
+                return ImageOps.fit(self.image, (width, height),
+                                    Image.ANTIALIAS)
             else:
                 thumb = self.image.copy()
                 thumb.thumbnail((width, height), Image.ANTIALIAS)


### PR DESCRIPTION
See also as in the following backtrace:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/site-packages/flask_admin/base.py", line 68, in inner
    return self._run_view(f, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/flask_admin/base.py", line 359, in _run_view
    return fn(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/flask_admin/model/base.py", line 1633, in edit_view
    if self.update_model(form, model):
  File "/usr/local/lib/python2.7/site-packages/flask_admin/contrib/sqla/view.py", line 1010, in update_model
    if not self.handle_view_exception(ex):
  File "/usr/local/lib/python2.7/site-packages/flask_admin/contrib/sqla/view.py", line 967, in handle_view_exception
    return super(ModelView, self).handle_view_exception(exc)
  File "/usr/local/lib/python2.7/site-packages/flask_admin/contrib/sqla/view.py", line 1006, in update_model
    form.populate_obj(model)
  File "/usr/local/lib/python2.7/site-packages/wtforms/form.py", line 96, in populate_obj
    field.populate_obj(obj, name)
  File "/app/cbg/admin_upload_s3.py", line 67, in populate_obj
    if self.data and self.data.filename and isinstance(self.data, FileStorage):
AttributeError: 'unicode' object has no attribute 'filename'
```
