### PR TITLE
remove storage_type_field and bucket_name_field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,17 +29,13 @@ Use with a Flask-Admin ModelView by overriding field types, and by passing in sp
                 base_path='/some/folder/static',
                 relative_path='some_image/',
                 url_relative_path='uploads/',
-                namegen=your_namegen_func_here,
-                storage_type_field='some_image_storage_type',
-                bucket_name_field='some_image_storage_bucket_name',
+                namegen=your_namegen_func_here
             ),
             some_file=dict(
                 base_path='/some/folder/static',
                 relative_path='some_file/',
                 namegen=your_namegen_func_here,
-                allowed_extensions=('pdf', 'txt'),
-                storage_type_field='some_file_storage_type',
-                bucket_name_field='some_file_storage_bucket_name',
+                allowed_extensions=('pdf', 'txt')
             ))
 
         def scaffold_form(self):


### PR DESCRIPTION
Hi,

I have removed the `storage_type_field` and the `bucked_name_field` and used `self.storage_type` and `self.bucket_name` instead.

Maybe I have misunderstood the purpose of these two field but the deletion of the files on S3 doesn't work because these lines returns an empty string:

```
storage_type = getattr(obj, self.storage_type_field, '')
bucket_name = getattr(obj, self.bucket_name_field, '')
```

Instead using `self.storage_type` and `self.bucket_name` returns the values we need.

Let me know if I misunderstood the behavior 😄 
